### PR TITLE
add different highlighting for json property names, although it is re…

### DIFF
--- a/color-theme.json
+++ b/color-theme.json
@@ -129,6 +129,30 @@
     {
       "name": "Heading",
       "foreground": "#82b1ff"
+    },
+    {
+      "name": "CssPropertyName",
+      "foreground": "#80cbc4"
+    },
+    {
+      "name": "CssSelector",
+      "foreground": "#ff5572"
+    },
+    {
+      "name": "Query",
+      "foreground": "#c792ea"
+    },
+    {
+      "name": "KeywordReturn",
+      "foreground": "#C792EA"
+    },
+    {
+      "name": "Text",
+      "foreground": "#bfc7d5"
+    },
+    {
+      "name": "JsonPropertyName",
+      "foreground": "#80cbc4"
     }
   ]
 }


### PR DESCRIPTION
…versed because currently highlighting strings differently in different languages is not supported